### PR TITLE
Add battery SOC and kWh usage stats

### DIFF
--- a/solis-modbus-esinv.yaml
+++ b/solis-modbus-esinv.yaml
@@ -282,7 +282,7 @@ sensor:
     name: Battery state of health (SoC)
     device_class: battery
     state_class: measurement
-    unit_of_measurement: %
+    unit_of_measurement: "%"
     register_type: read
     address: 33139
     value_type: U_WORD

--- a/solis-modbus-esinv.yaml
+++ b/solis-modbus-esinv.yaml
@@ -277,7 +277,37 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    name: Battery SOC
+    device_class: battery
+    state_class: measurement
+    unit_of_measurement: %
+    register_type: read
+    address: 33139
+    value_type: U_WORD
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    name: Total battery charge
+    device_class: energy
+    state_class: total_increasing
+    unit_of_measurement: kWh
+    register_type: read
+    address: 33161
+    value_type: U_DWORD
+    skip_updates: 10
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    name: Total battery discharge
+    device_class: energy
+    state_class: total_increasing
+    unit_of_measurement: kWh
+    register_type: read
+    address: 33165
+    value_type: U_DWORD
+    skip_updates: 10
 
+    
 text_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_master

--- a/solis-modbus-esinv.yaml
+++ b/solis-modbus-esinv.yaml
@@ -279,13 +279,14 @@ sensor:
       - multiply: 0.01
   - platform: modbus_controller
     modbus_controller_id: modbus_master
-    name: Battery SOC
+    name: Battery state of health (SoC)
     device_class: battery
     state_class: measurement
     unit_of_measurement: %
     register_type: read
     address: 33139
     value_type: U_WORD
+    skip_updates: 10
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Total battery charge


### PR DESCRIPTION
Adds Battery SOC (33139), Discharge kWh (33165) and Charge kWh (33161) value reads.

Linked to https://github.com/hn/ginlong-solis/issues/14

Not tested on live inverter (inverter is being installed in August).
