### PR TITLE
ESPHome 2024.6.3 - 'ota' requires a 'platform' key but it was not specified

### DIFF
--- a/solis-esphome-emw3080.yaml
+++ b/solis-esphome-emw3080.yaml
@@ -58,6 +58,7 @@ api:
     key: !secret api_encryption_key
 
 ota:
+- platform: esphome
   password: !secret ota_password
 
 wifi:

--- a/solis-esphome-emw3080.yaml
+++ b/solis-esphome-emw3080.yaml
@@ -58,8 +58,8 @@ api:
     key: !secret api_encryption_key
 
 ota:
-- platform: esphome
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid

--- a/solis-esphome-esp8266.yaml
+++ b/solis-esphome-esp8266.yaml
@@ -49,6 +49,7 @@ api:
     key: !secret api_encryption_key
 
 ota:
+- platform: esphome
   password: !secret ota_password
 
 wifi:

--- a/solis-esphome-esp8266.yaml
+++ b/solis-esphome-esp8266.yaml
@@ -49,8 +49,8 @@ api:
     key: !secret api_encryption_key
 
 ota:
-- platform: esphome
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Fix for issue https://github.com/hn/ginlong-solis/issues/39

Added `- platform: esphome` to the OTA function of solis-esphome-emw3080.yaml and solis-esphome-esp8266.yaml

My first ever pull request, not sure if it works or is done correctly.... sorry in advance.