### PR TITLE
Fix ESINV Battery/Grid/Load Fault and battery power reporting

### DIFF
--- a/solis-modbus-esinv.yaml
+++ b/solis-modbus-esinv.yaml
@@ -119,7 +119,7 @@ binary_sensor:
     address: 33121
     bitmask: 0x0100 # bit 08
     filters:
-      invert:
+      - invert: # Modbus returns 0 for load fault, 1 for OK
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Grid fault
@@ -128,7 +128,7 @@ binary_sensor:
     address: 33121
     bitmask: 0x0200 # bit 09
     filters:
-      invert:
+      - invert: # Modbus returns 0 for grid fault, 1 for OK
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Battery fault
@@ -137,7 +137,7 @@ binary_sensor:
     address: 33121
     bitmask: 0x0400 # bit 10
     filters:
-      invert:
+      - invert: # Modbus returns 0 for battery fault, 1 for OK
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Grid Surge Warn
@@ -450,7 +450,7 @@ sensor:
     address: 33149
     value_type: S_DWORD
     accuracy_decimals: 0
-    lambda:
+    lambda: |-
         if (id(battery_current_direction).state) {
             return x;
         } else {

--- a/solis-modbus-esinv.yaml
+++ b/solis-modbus-esinv.yaml
@@ -118,6 +118,8 @@ binary_sensor:
     register_type: read
     address: 33121
     bitmask: 0x0100 # bit 08
+    filters:
+      invert:
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Grid fault
@@ -125,6 +127,8 @@ binary_sensor:
     register_type: read
     address: 33121
     bitmask: 0x0200 # bit 09
+    filters:
+      invert:
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Battery fault
@@ -132,6 +136,8 @@ binary_sensor:
     register_type: read
     address: 33121
     bitmask: 0x0400 # bit 10
+    filters:
+      invert:
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Operation status Grid Surge Warn
@@ -149,6 +155,7 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Battery current direction
+    id: battery_current_direction
     device_class: battery_charging # on means charging, off means not charging
     register_type: read
     address: 33135
@@ -443,6 +450,12 @@ sensor:
     address: 33149
     value_type: S_DWORD
     accuracy_decimals: 0
+    lambda:
+        if (id(battery_current_direction).state) {
+            return x;
+        } else {
+            return -x;
+        }
   - platform: modbus_controller
     modbus_controller_id: modbus_master
     name: Total battery charge


### PR DESCRIPTION
Fixes #56 

  * ESINV Battery, Grid and Load Fault flags are inverse logic, ie 1=OK, but HA expects 1=problem. Add invert filters for these.
  * ESINV Battery Power is always positive regardless of power direction. Use the Battery Current Direction to make discharge show as negative power values.