### PR TITLE
Add ESINV expansion to allow timer/clock get/set

### DIFF
--- a/solis-modbus-esinv-addon-timer.yaml
+++ b/solis-modbus-esinv-addon-timer.yaml
@@ -1,0 +1,424 @@
+#
+# Timer extension for Solis
+#
+# Requires a time object called "network_time"
+#
+
+# Timer settings are a bit "fun" and not documented in the Modbus spec.
+# For protocol info, see -
+# https://solis-exporter.readthedocs.io/en/latest/references/
+# https://solis-exporter.readthedocs.io/en/latest/packet_log/
+# https://akkudoktor.net/uploads/short-url/860gETtHwhFvy2a9AiIzDqO2lT5.pdf
+#
+# Another source of HA code and ideas is this addon:
+#  https://github.com/fboundy/ha_solis_modbus
+
+# Energy Storage Mode is set via register 43110 (Energy storage control switch).
+#  Value 33 is "Self Use, Spontaneous mode",
+#        35 is "Self Use, Optimised Revenie mode (timed chg/dis)"
+#
+# Timers are stored as 8x consecutive U16 Modbus holding variables starting at:
+#   - 43143 (Timer 1)
+#   - 43153 (Timer 2)
+#   - 43163 (Timer 3)
+# The variables are as follows:
+#   - +0: Charge Start Hour
+#   - +1: Charge Start Minute
+#   - +2: Charge Stop Hour
+#   - +3: Charge Stop Minute
+#   - +4: Discharge Start Hour
+#   - +5: Discharge Start Minute
+#   - +6: Discharge Stop Hour
+#   - +7: Discharge Stop Minute
+# The inverter won't accept single writes to these: as a minimum, the Charge
+# Start Hr/Min and Charge Stop Hr/Min must be written in a single Write
+# Multiple Registers command. I assume this is the same for the Discharge timer.
+#
+# Of course, you can write the charge and discharge timers at the same time if
+# you like.
+
+# The inverter clock is stored in six consecutive Modbus U16 input registers:
+#  INV:
+#   - 33022: Year
+#   - 33023: Month
+#   - 33034: Day
+#   - 33025: Hour
+#   - 33026: Minute
+#   - 33027: Second
+#  To set the clock, write to 43000 in the same format, see https://solis-exporter.readthedocs.io/en/latest/packet_log/
+#  These may also start at 3073, see https://diysolarforum.com/resources/solis-grid-tied-inverters-2018-rs485-modbus-communication-protocol.272/download
+
+sensor:
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    id: inverter_clock_internal
+    name: "Inverter clock (internal)"
+    address: 33022
+    register_count: 6
+    register_type: read
+    value_type: U_WORD  # irrelevant because of the register_count override but meh
+    skip_updates: 10      # Doesn't change frequently, update every 10 updates
+    internal: true
+
+    lambda: |-
+      uint16_t t_year  = (data[item->offset+ 0] << 8) | (data[item->offset+ 1]);
+      uint16_t t_month = (data[item->offset+ 2] << 8) | (data[item->offset+ 3]);
+      uint16_t t_day   = (data[item->offset+ 4] << 8) | (data[item->offset+ 5]);
+      uint16_t t_hour  = (data[item->offset+ 6] << 8) | (data[item->offset+ 7]);
+      uint16_t t_min   = (data[item->offset+ 8] << 8) | (data[item->offset+ 9]);
+      uint16_t t_sec   = (data[item->offset+10] << 8) | (data[item->offset+11]);
+      
+      // Inverter doesn't have a century byte. If it's still in use in 75
+      // years, you'll want to change this.
+      t_year += 2000;
+
+      id(inverter_clock).publish_state(str_sprintf("%04u-%02u-%02u %02u:%02u:%02u", 
+        t_year, t_month, t_day, t_hour, t_min, t_sec));
+        
+      return NAN;
+      
+      
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    id: timed_charge_1_internal
+    name: "Timed Charge 1 (internal)"
+    address: 43143
+    register_count: 4
+    register_type: holding
+    value_type: U_WORD  # irrelevant because of the register_count override but meh
+    skip_updates: 10      # Doesn't change frequently, update every 10 updates
+    internal: true
+
+    lambda: |-
+      /*
+      ESP_LOGI("RLambda", "Lambda incoming value=%f - data array size is %d", x, data.size());
+      ESP_LOGI("RLambda", "Sensor properties: address = 0x%X (%u), offset = 0x%X value type=%d", item->start_address, item->start_address, item->offset, item->sensor_value_type);
+      int i=0 ;
+      for (auto val : data) {
+        ESP_LOGI("RLambda","data[%d]=0x%02X (%d)", i, data[i], data[i]);
+        i++;
+      }
+      */
+      // data here is bytes, modbus registers are words, msb first
+      uint16_t s_hours = (data[item->offset+0] << 8) | (data[item->offset+1]);
+      uint16_t s_mins  = (data[item->offset+2] << 8) | (data[item->offset+3]);
+      uint16_t e_hours = (data[item->offset+4] << 8) | (data[item->offset+5]);
+      uint16_t e_mins  = (data[item->offset+6] << 8) | (data[item->offset+7]);
+
+      if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+          (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+      {
+        //ESP_LOGI("RLambda", "Out of bounds");
+        id(timed_charge_1).publish_state("");
+        return NAN;
+      }
+
+      // Convert to string and push to the text template
+      id(timed_charge_1).publish_state(str_sprintf("%02u:%02u-%02u:%02u", s_hours, s_mins, e_hours, e_mins));
+
+      ESP_LOGI("RLambda", "Read1: %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+      return ((((uint32_t)s_hours * 100) + (uint32_t)s_mins) * 10000) +
+             ((((uint32_t)e_hours * 100) + (uint32_t)e_mins));
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    id: timed_charge_2_internal
+    name: "Timed Charge 2 (internal)"
+    address: 43153
+    register_count: 4
+    register_type: holding
+    value_type: U_WORD  # irrelevant because of the register_count override but meh
+    skip_updates: 10      # Doesn't change frequently, update every 10 updates
+    internal: true
+
+    lambda: |-
+      /*
+      ESP_LOGI("RLambda", "Lambda incoming value=%f - data array size is %d", x, data.size());
+      ESP_LOGI("RLambda", "Sensor properties: address = 0x%X (%u), offset = 0x%X value type=%d", item->start_address, item->start_address, item->offset, item->sensor_value_type);
+      int i=0 ;
+      for (auto val : data) {
+        ESP_LOGI("RLambda","data[%d]=0x%02X (%d)", i, data[i], data[i]);
+        i++;
+      }
+      */
+
+      // data here is bytes, modbus registers are words, msb first
+      uint16_t s_hours = (data[item->offset+0] << 8) | (data[item->offset+1]);
+      uint16_t s_mins  = (data[item->offset+2] << 8) | (data[item->offset+3]);
+      uint16_t e_hours = (data[item->offset+4] << 8) | (data[item->offset+5]);
+      uint16_t e_mins  = (data[item->offset+6] << 8) | (data[item->offset+7]);
+
+      if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+          (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+      {
+        //ESP_LOGI("RLambda", "Out of bounds");
+        id(timed_charge_2).publish_state("");
+        return NAN;
+      }
+
+      // Convert to string and push to the text template
+      id(timed_charge_2).publish_state(str_sprintf("%02u:%02u-%02u:%02u", s_hours, s_mins, e_hours, e_mins));
+
+      ESP_LOGI("RLambda", "Read2: %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+      
+      return ((((uint32_t)s_hours * 100) + (uint32_t)s_mins) * 10000) +
+             ((((uint32_t)e_hours * 100) + (uint32_t)e_mins));
+
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_master
+    id: timed_charge_3_internal
+    name: "Timed Charge 3 (internal)"
+    address: 43163
+    register_count: 4
+    register_type: holding
+    value_type: U_WORD  # irrelevant because of the register_count override but meh
+    skip_updates: 10      # Doesn't change frequently, update every 10 updates
+    internal: true
+
+    lambda: |-
+      /*
+      ESP_LOGI("RLambda", "Lambda incoming value=%f - data array size is %d", x, data.size());
+      ESP_LOGI("RLambda", "Sensor properties: address = 0x%X (%u), offset = 0x%X value type=%d", item->start_address, item->start_address, item->offset, item->sensor_value_type);
+      int i=0 ;
+      for (auto val : data) {
+        ESP_LOGI("RLambda","data[%d]=0x%02X (%d)", i, data[i], data[i]);
+        i++;
+      }
+      */
+
+      // data here is bytes, modbus registers are words, msb first
+      uint16_t s_hours = (data[item->offset+0] << 8) | (data[item->offset+1]);
+      uint16_t s_mins  = (data[item->offset+2] << 8) | (data[item->offset+3]);
+      uint16_t e_hours = (data[item->offset+4] << 8) | (data[item->offset+5]);
+      uint16_t e_mins  = (data[item->offset+6] << 8) | (data[item->offset+7]);
+
+      if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+          (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+      {
+        //ESP_LOGI("RLambda", "Out of bounds");
+        id(timed_charge_3).publish_state("");
+        return NAN;
+      }
+
+      // Convert to string and push to the text template
+      id(timed_charge_3).publish_state(str_sprintf("%02u:%02u-%02u:%02u", s_hours, s_mins, e_hours, e_mins));
+
+      ESP_LOGI("RLambda", "Read3: %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+      // Update the internal state too
+      return ((((uint32_t)s_hours * 100) + (uint32_t)s_mins) * 10000) +
+             ((((uint32_t)e_hours * 100) + (uint32_t)e_mins));
+
+
+text:
+  - platform: template
+    name: "Inverter clock"
+    id: inverter_clock
+    optimistic: false
+    mode: TEXT
+    setup_priority: -100
+    set_action: 
+      then:
+        - lambda: |-
+            unsigned int t_year, t_month, t_day, t_hour, t_min, t_sec;
+
+            ESP_LOGI("WLambda", "Clock Write Lambda entry: '%s'", x.c_str());
+            // New value is in the "x" variable
+            if (sscanf(x.c_str(), "%04u-%02u-%02u %02u:%02u:%02u",
+                    &t_year, &t_month, &t_day, &t_hour, &t_min, &t_sec) != 6) {
+              ESP_LOGI("WLambda", "Bad format");
+              return;
+            }
+            
+            // Inverter doesn't have a century byte. If it's still in use in 75
+            // years, you'll want to change this.
+            t_year -= 2000;
+            
+            if ((t_year < 0) || (t_year > 99) || (t_month < 1) || (t_month > 12) ||
+                (t_day  < 1) || (t_day  > 31) ||
+                (t_hour < 0) || (t_hour > 23) || (t_min   < 0) || (t_min   > 59) ||
+                (t_sec  < 0) || (t_sec  > 59))
+            {
+              ESP_LOGI("WLambda", "Clock Values out of bounds");
+              return;
+            }
+            
+            esphome::modbus_controller::ModbusController *controller = id(modbus_master);
+
+            // create the payload
+            std::vector<uint16_t> payload = {
+              (uint16_t)t_year, (uint16_t)t_month, (uint16_t)t_day,
+              (uint16_t)t_hour, (uint16_t)t_min, (uint16_t)t_sec,
+              };
+
+            // Create a modbus command item with the time information as the payload
+            esphome::modbus_controller::ModbusCommandItem set_clock_command =
+                esphome::modbus_controller::ModbusCommandItem::create_write_multiple_command(controller, 43000, 6, payload);
+            // Submit the command to the send queue
+            controller->queue_command(set_clock_command);
+            ESP_LOGI("WLambda", "Clock set");
+
+
+  - platform: template
+    name: "Timed Charge 1"
+    id: timed_charge_1
+    optimistic: false
+    mode: TEXT
+    setup_priority: -100
+    set_action: 
+      then:
+        - lambda: |-
+            ESP_LOGI("WLambda", "Write Lambda entry: '%s'", x.c_str());
+            // New value is in the "x" variable
+            unsigned int s_hours, s_mins, e_hours, e_mins;
+            if (sscanf(x.c_str(), "%02u:%02u-%02u:%02u", &s_hours, &s_mins, &e_hours, &e_mins) != 4) {
+              ESP_LOGI("WLambda", "Bad format");
+              return;
+            }
+            ESP_LOGI("WLambda", "Write Lambda %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+            if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+                (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+            {
+              ESP_LOGI("WLambda", "Values out of bounds");
+              return;
+            }
+
+            esphome::modbus_controller::ModbusController *controller = id(modbus_master);
+
+            // create the payload
+            std::vector<uint16_t> payload = {
+              (uint16_t)s_hours, (uint16_t)s_mins, 
+              (uint16_t)e_hours, (uint16_t)e_mins,
+              0, 0,
+              0, 0
+              };
+
+            // Create a modbus command item with the time information as the payload
+            esphome::modbus_controller::ModbusCommandItem set_timer_command =
+                esphome::modbus_controller::ModbusCommandItem::create_write_multiple_command(controller, 43143, 8, payload);
+            // Submit the command to the send queue
+            controller->queue_command(set_timer_command);
+            ESP_LOGI("WLambda", "Timer1 set to %02u:%02u - %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+
+  - platform: template
+    name: "Timed Charge 2"
+    id: timed_charge_2
+    optimistic: false
+    mode: TEXT
+    setup_priority: -100
+    set_action: 
+      then:
+        - lambda: |-
+            ESP_LOGI("WLambda", "Write Lambda entry: '%s'", x.c_str());
+            // New value is in the "x" variable
+            unsigned int s_hours, s_mins, e_hours, e_mins;
+            if (sscanf(x.c_str(), "%02u:%02u-%02u:%02u", &s_hours, &s_mins, &e_hours, &e_mins) != 4) {
+              ESP_LOGI("WLambda", "Bad format");
+              return;
+            }
+            ESP_LOGI("WLambda", "Write Lambda %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+            if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+                (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+            {
+              ESP_LOGI("WLambda", "Values out of bounds");
+              return;
+            }
+
+            esphome::modbus_controller::ModbusController *controller = id(modbus_master);
+
+            // create the payload
+            std::vector<uint16_t> payload = {
+              (uint16_t)s_hours, (uint16_t)s_mins, 
+              (uint16_t)e_hours, (uint16_t)e_mins,
+              0, 0,
+              0, 0
+              };
+
+            // Create a modbus command item with the time information as the payload
+            esphome::modbus_controller::ModbusCommandItem set_timer_command =
+                esphome::modbus_controller::ModbusCommandItem::create_write_multiple_command(controller, 43153, 8, payload);
+            // Submit the command to the send queue
+            controller->queue_command(set_timer_command);
+            ESP_LOGI("WLambda", "Timer2 set to %02u:%02u - %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+
+  - platform: template
+    name: "Timed Charge 3"
+    id: timed_charge_3
+    optimistic: false
+    mode: TEXT
+    setup_priority: -100
+    set_action: 
+      then:
+        - lambda: |-
+            ESP_LOGI("WLambda", "Write Lambda entry: '%s'", x.c_str());
+            // New value is in the "x" variable
+            unsigned int s_hours, s_mins, e_hours, e_mins;
+            if (sscanf(x.c_str(), "%02u:%02u-%02u:%02u", &s_hours, &s_mins, &e_hours, &e_mins) != 4) {
+              ESP_LOGI("WLambda", "Bad format");
+              return;
+            }
+            ESP_LOGI("WLambda", "Write Lambda %02u:%02u to %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+            if ((s_hours < 0) || (s_hours > 23) || (s_mins < 0) || (s_mins > 59) ||
+                (e_hours < 0) || (e_hours > 23) || (e_mins < 0) || (e_mins > 59))
+            {
+              ESP_LOGI("WLambda", "Values out of bounds");
+              return;
+            }
+
+            esphome::modbus_controller::ModbusController *controller = id(modbus_master);
+
+            // create the payload -- charge start h, start m, end h, end m -- then same for discharge
+            std::vector<uint16_t> payload = {
+              (uint16_t)s_hours, (uint16_t)s_mins, 
+              (uint16_t)e_hours, (uint16_t)e_mins,
+              0, 0,
+              0, 0
+              };
+
+            // Create a modbus command item with the time information as the payload
+            esphome::modbus_controller::ModbusCommandItem set_timer_command =
+                esphome::modbus_controller::ModbusCommandItem::create_write_multiple_command(controller, 43163, 8, payload);
+            // Submit the command to the send queue
+            controller->queue_command(set_timer_command);
+            ESP_LOGI("WLambda", "Timer3 set to %02u:%02u - %02u:%02u", s_hours, s_mins, e_hours, e_mins);
+
+button:
+  - platform: template
+    name: "Sync inverter clock"
+    on_press:
+      then:
+        - lambda: |-
+            ESP_LOGI("ClockSync", "Synchronising inverter clock to ESP");
+            
+            // Get local time from ESPTime
+            auto time = id(network_time).now();
+            if (!time.is_valid()) {
+                ESP_LOGE("ClockSync", "Local time on ESP is not valid");
+                return;
+            }
+
+            esphome::modbus_controller::ModbusController *controller = id(modbus_master);
+
+            // create the payload
+            std::vector<uint16_t> payload = {
+              (uint16_t)time.year, (uint16_t)time.month, (uint16_t)time.day_of_month,
+              (uint16_t)time.hour, (uint16_t)time.minute, (uint16_t)time.second
+              };
+              
+            // Create a modbus command item with the time information as the payload
+            esphome::modbus_controller::ModbusCommandItem set_clock_command =
+                esphome::modbus_controller::ModbusCommandItem::create_write_multiple_command(controller, 43000, 6, payload);
+            
+            // Submit the command to the send queue
+            controller->queue_command(set_clock_command);
+            
+            ESP_LOGI("ClockSync", "Inverter clock set to %04u-%02u-%02u %02u:%02u:%02u",
+                          time.year, time.month, time.day_of_month,
+                          time.hour, time.minute, time.second);


### PR DESCRIPTION
I needed to set the clock and the three timers on the ESINV inverter to manage ESS battery charge and discharge periods. This extension YAML adds support for it.

To use it, create a time element in the root YAML which sets the ESP's clock from Home Assistant:
```yaml
# Get time from HA
time:
  - platform: homeassistant
    id: network_time
```

And add this as a package:

```yaml
packages:
  # Uncomment exactly one line depending on your device type
  #inv:   !include custom_components/ginlong-solis/solis-modbus-inv.yaml
  esinv: !include custom_components/ginlong-solis/solis-modbus-esinv.yaml
  #epm:   !include custom_components/ginlong-solis/solis-modbus-epm.yaml

  # ESINV extension: timers and inverter clock
```

For the inverter to honour this, it must be in Self Use mode, and the Self Use timers need to be enabled. This can be done via a Modbus write (the [Solis Exporter documentation](https://solis-exporter.readthedocs.io) explains how to do it) or via the HMI interface on the inverter (go into advanced settings, enter PIN, energy storage mode, all off except Self Use, enable Time Of Use).