### PR TITLE
Fix Meter Reactive Power valid unit

### DIFF
--- a/solis-modbus-inv-addon-acr10r-1ph.yaml
+++ b/solis-modbus-inv-addon-acr10r-1ph.yaml
@@ -62,7 +62,7 @@ sensor:
     name: Meter Reactive Power
     device_class: reactive_power
     state_class: measurement
-    unit_of_measurement: VAr
+    unit_of_measurement: var
     register_type: read
     address: 3264 # = 3265 - 1
     value_type: S_DWORD


### PR DESCRIPTION
Fixes

> 2025-12-31 08:48:28.569 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.ginlong_solis_meter_reactive_power (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement 'VAr' which is not a valid unit for the device class ('reactive_power') it is using; expected one of ['mvar', 'var', 'kvar']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+esphome%22